### PR TITLE
[doc] [*] [v0.2.0] using branch `develop` instead of branches with prefix `dev/`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 We recommend that developers following the rules [here](https://jeffkreeftmeijer.com/git-flow/git-flow.png).
 
 - Branch `main` with stable code and tags on it.
-- Branches starting with prefix `dev/` for "next release" development.
+- Branch `develop` for "next release" development.
 - Feature branches start with prefix `feat/`
 - Release branches start with prefix `release/`
 - Hotfix branches start with prefix `hotfix/`
@@ -14,7 +14,7 @@ We recommend that developers following the rules [here](https://jeffkreeftmeijer
 
 - Fork the repository or create branches.
 - Checkout your branch like a feature or bugfix.
-- Make a pull request to the development branch of this repository.
+- Make a pull request to the `develop` branch of this repository.
 - Wait for review and PR merged.
 
 ---


### PR DESCRIPTION
- Using branch `develop` instead of branches with prefix `dev/`